### PR TITLE
[step9, 10]Change locale

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,3 +54,5 @@ end
 
 gem 'slim-rails'
 gem 'webpacker', github: 'rails/webpacker'
+
+gem 'rails-i18n', '~> 5.1' 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.4.3)
       actionpack (= 5.2.4.3)
       activesupport (= 5.2.4.3)
@@ -196,6 +199,7 @@ DEPENDENCIES
   pg (~> 1.1.4)
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-i18n (~> 5.1)
   sass-rails (~> 5.0.7)
   selenium-webdriver
   slim-rails

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,6 +13,9 @@
  *= require_tree .
  *= require_self
  */
+ [v-cloak]{
+     display: none;
+ }
 
 
 .task-title{

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,5 @@
 class HomeController < ApplicationController
   def top
-    I18n.locale = :ja
-
-    require 'date'
-    @time = Time.current
     @tasks = Task.all
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,9 @@
 class HomeController < ApplicationController
   def top
+    I18n.locale = :ja
+
+    require 'date'
+    @time = Time.current
     @tasks = Task.all
   end
 

--- a/app/controllers/js_controller.rb
+++ b/app/controllers/js_controller.rb
@@ -1,6 +1,6 @@
 class JsController < ApplicationController
   def ajax_create
-    @taskTitle = params[:taskTitle]　
+    @taskTitle = params[:taskTitle]
 
     @task = Task.new
     @newTask = Task.create(title: @taskTitle, deadline: Time.zone.now, priority: rand(0..2), state: rand(0..2), memo: 'test', user_id: 1, category_id: 1)
@@ -24,7 +24,7 @@ class JsController < ApplicationController
     @state = params[:state]
     @memo = params[:memo]
 
-    @task = Task.find_by(id: @task_id)
+    @task = Task.find(id: @task_id)
     @task.title = @title
     @task.deadline = @deadline
     @task.priority = @priority
@@ -37,7 +37,7 @@ class JsController < ApplicationController
 
   def ajax_delete
     @task_id = params[:task_id]
-    @task = Task.find_by(id: @task_id)
+    @task = Task.find(id: @task_id)
     @task.destroy
 
     render

--- a/app/controllers/js_controller.rb
+++ b/app/controllers/js_controller.rb
@@ -24,7 +24,7 @@ class JsController < ApplicationController
     @state = params[:state]
     @memo = params[:memo]
 
-    @task = Task.find(id: @task_id)
+    @task = Task.find(@task_id)
     @task.title = @title
     @task.deadline = @deadline
     @task.priority = @priority
@@ -37,7 +37,7 @@ class JsController < ApplicationController
 
   def ajax_delete
     @task_id = params[:task_id]
-    @task = Task.find(id: @task_id)
+    @task = Task.find(@task_id)
     @task.destroy
 
     render

--- a/app/controllers/js_controller.rb
+++ b/app/controllers/js_controller.rb
@@ -1,10 +1,16 @@
 class JsController < ApplicationController
   def ajax_create
-    @taskTitle = params[:taskTitle]
+    @title = params[:taskTitle]
+    @message = ''
 
-    @task = Task.new
-    @newTask = Task.create(title: @taskTitle, deadline: Time.zone.now, priority: rand(0..2), state: rand(0..2), memo: 'test', user_id: 1, category_id: 1)
-    
+    if(@title == '')
+      @message = I18n.t('error.noTitle')
+    else
+      @task = Task.new
+      @newTask = Task.create(title: @taskTitle, deadline: Time.zone.now, priority: rand(0..2), state: rand(0..2), memo: 'test', user_id: 1, category_id: 1)
+      @title = @newtask.title
+      @id = @newtask.id
+    end
     render
   end
 
@@ -17,20 +23,25 @@ class JsController < ApplicationController
   end
 
   def ajax_edit
-    @task_id = params[:task_id]
     @title = params[:title]
+    @task_id = params[:task_id]
     @deadline = params[:deadline]
     @priority = params[:priority]
     @state = params[:state]
     @memo = params[:memo]
+    @message = ''
 
-    @task = Task.find(@task_id)
-    @task.title = @title
-    @task.deadline = @deadline
-    @task.priority = @priority
-    @task.state = @state
-    @task.memo = @memo
-    @task.save
+    if(@title == '')
+      @message = I18n.t('error.noTitle')
+    else
+      @task = Task.find(@task_id)
+      @task.title = @title
+      @task.deadline = @deadline
+      @task.priority = @priority
+      @task.state = @state
+      @task.memo = @memo
+      @task.save
+    end
     
     render
   end

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -14,6 +14,8 @@ html lang="ja"
 
             main
                 h1 タスク一覧
+                div.validation-message.hidden#validation-message-create
+                    | {{ validationMessages.create }}
 
                 = form_with url: js_ajax_create_path do |f|
                     = f.text_field :taskTitle, class: "input-task-title", "v-model": "newTaskTitle"
@@ -32,6 +34,7 @@ html lang="ja"
                                 = f.text_field :task_id, class: "hidden"
                                 = f.submit '削除', class: "delete-btn delete-task", "@click": "deleteTask"
 
+
                 div.modal-close#modal-background @click="hideModal"
 
                 div.modal#modal-edit
@@ -44,6 +47,9 @@ html lang="ja"
                             = f.select :state, [["未着手", "0"], ["着手", "1"], ["完了", "2"]], "v-model": "edittingTask.state"
                             = f.text_area :memo, class: "input-edit", "v-model": "edittingTask.memo"
                             = f.submit '完了', class: "submit-btn submit-editted-title", "@click": "submitEditedTask"
+                        div.validation-message.hidden#validation-message-edit
+                            | {{ validationMessages.edit }}
+                    
             footer
                 div#flash-message.hidden 
                     | {{ flashMessage }}
@@ -53,7 +59,11 @@ html lang="ja"
         const vm = new Vue({
             el: '#vm-container',
             data: {
-                flashMessage: 'init',
+                flashMessage: '',
+                validationMessages: {
+                    create: '',
+                    edit: ''
+                },
                 newTaskTitle: '',
                 edittingTask: {
                     task_id: '',
@@ -72,8 +82,7 @@ html lang="ja"
                     console.log('submitting new task');
                 },
                 submitEditedTask: function(){
-
-                    this.hideModal();
+                    console.log('submitting edittedtask');
                 },
                 editTask: function(event){
                     this.autoInput(event);
@@ -133,7 +142,16 @@ html lang="ja"
                         $('#flash-message').removeClass(classes.messageCategory);
                         $('#flash-message').addClass('hidden');
                     }, 2000);
+                },
+                displayValidationMessage: function(message, messageCategory, element){
+                    
+                    this.validationMessages[messageCategory] = message;
+                    $(element).removeClass('hidden');
+                    setTimeout(function(){
+                        $(element).addClass('hidden');
+                    }, 2000);
                 }
+
             },
             created: function(){
                 // Vueの嬉しさを全く活かさない書き方😞

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -9,6 +9,8 @@ html lang="ja"
     body
         div#vm-container
             header
+                h2 = t 'greetings.hello'
+                h2 = l(Time.current)
 
             main
                 h1 タスク一覧

--- a/app/views/js/ajax_create.js.erb
+++ b/app/views/js/ajax_create.js.erb
@@ -1,12 +1,16 @@
-createTask('<%= "#{ @newTask.title}" %>', '<%= "#{ @newTask.id}" %>');
+if('<%= "#{ @message}" %>'){
+    vm.displayValidationMessage('<%= "#{ @message}" %>', 'create', '#validation-message-create');
+}else{
+    createTask('<%= "#{ @title}" %>', '<%= "#{ @id}" %>');
 
-function createTask(title, id){
-    $('#tasks-container').prepend(`
-        <div class="task-container">
-            <li class="task-title" @click="editTask">` + title + `</li>
-            <span class="task-id">` + id + `</span>
-        </div>
-    `);
-    vm.newTaskTitle = '';
-    vm.displayFlashMessage('タスクを作成した！', 'success');
+    function createTask(title, id){
+        $('#tasks-container').prepend(`
+            <div class="task-container">
+                <li class="task-title" @click="editTask">` + title + `</li>
+                <span class="task-id">` + id + `</span>
+            </div>
+        `);
+        vm.newTaskTitle = '';
+        vm.displayFlashMessage('タスクを作成した！', 'success');
+    }
 }

--- a/app/views/js/ajax_edit.js.erb
+++ b/app/views/js/ajax_edit.js.erb
@@ -1,11 +1,15 @@
-editTask(
-    '<%= "#{ @task_id }" %>',
-    '<%= "#{ @title }" %>',
-    '<%= "#{ @deadline }" %>',
-    '<%= "#{ @priority }" %>',
-    '<%= "#{ @state }" %>',
-    '<%= "#{ @memo }" %>'
-);
+if('<%= "#{ @message }" %>'){
+    vm.displayValidationMessage('<%= "#{ @message}" %>', 'edit', '#validation-message-edit');
+}else{
+    editTask(
+        '<%= "#{ @task_id }" %>',
+        '<%= "#{ @title }" %>',
+        '<%= "#{ @deadline }" %>',
+        '<%= "#{ @priority }" %>',
+        '<%= "#{ @state }" %>',
+        '<%= "#{ @memo }" %>'
+    );
+}
 
 function editTask(task_id, title, deadline, priority, state, memo){
     // Vueの嬉しさを全く活かさない書き方😞
@@ -29,6 +33,7 @@ function editTask(task_id, title, deadline, priority, state, memo){
             vm.edittingTask.state = '';
             vm.edittingTask.memo = '';
             vm.displayFlashMessage('タスクを編集した！', 'success');
+            vm.hideModal();
 
             return false;
         }

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,10 @@ module App
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
     config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,6 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  greetings: 
+      hello: 'Hello World'
+      whatsup: "What's up?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,5 +31,8 @@
 
 en:
   greetings: 
-      hello: 'Hello World'
-      whatsup: "What's up?"
+    hello: 'Hello World'
+    whatsup: "What's up?"
+  error:
+    noTitle: 'Input the title.'
+  

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,5 +2,5 @@ ja:
     greetings: 
         hello: 'こんにちは世界'
         whatsup: "元気？"
-    time:
-        current: "%Y年%m月%d日"
+    error:
+        noTitle: 'タイトルを入力してください'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,6 @@
+ja:
+    greetings: 
+        hello: 'こんにちは世界'
+        whatsup: "元気？"
+    time:
+        current: "%Y年%m月%d日"


### PR DESCRIPTION
ステップ10がすぐ終わる内容だったため、ステップ9, 10のPRをまとめてしまいました。

# このステップの内容
### ステップ9: アプリの日本語部分を共通化しよう
- Railsのi18nの仕組みを利用して、validation エラーメッセージを日本語で出力するようにしましょう
### ステップ10: Railsのタイムゾーンを設定しよう
- Railsのタイムゾーンを日本（東京）に設定しましょう

# このステップでやったこと
デフォルトロケールとタイムゾーンを`config/application.rb`で設定。`config/locale`配下の`ja.yml` `en.yml`にバリデーションメッセージを記載。タスクの編集・作成の際に、タイトルの入力が空文字列だった場合はメッセージを出力するようにした。

# 動作確認
タスクの編集・作成時にタスクのタイトル入力欄を空にしてフォーム送信→エラーメッセージ出力

# 参考資料
- [[初学者]Railsのi18nによる日本語化対応](https://qiita.com/shimadama/items/7e5c3d75c9a9f51abdd5)
- [RubyとRailsのバージョン上げたらactive_adminでI18n::MissingTranslationData in 〜エラーがでた](http://log.miraoto.com/2013/10/875/)