### PR TITLE
[step13]Deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,13 @@ Dockerfileに組み込みたいが、Privilegedで起動扠せねばならぬ問
 | id | int|
 | title | string |
 | user_id | int |
+
+
+## デプロイの方法
+GitHubと連携してherokuにデプロイ。このリポジトリのmasterブランチから自動でデプロイを行うように設定した。手動でデプロイを行う場合は、[herokuアプリのダッシュボード](https://dashboard.heroku.com/apps/do-do-do/deploy/github)のデプロイタブから、Manual deployのセクションでデプロイするブランチを選択し、`Deploy Branch`を選択する。本番環境での`heroku run`コマンドの実行や、ログの確認もコンソールから行うことができる。
+
+## バージョン情報
+- Ruby 2.6.2
+- Rails 5.2.4.3
+- gem 3.0.3
+- PostgreSQL 9.6.18

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::Base
+    before_action :basic
+
+    private
+    def basic
+        authenticate_or_request_with_http_basic do |name, password|
+            name == ENV['BASIC_AUTH_NAME'] && password == ENV['BASIC_AUTH_PASSWORD'] if Rails.env == "production"
+        end
+    end
 end


### PR DESCRIPTION
# このステップの内容
- masterブランチにシンプルなタスク管理システムができたので、デプロイしてみましょう。
- Herokuにデプロイを実施してみましょう
  - アカウントがなければ作成しましょう
- デプロイされたHeroku上のアプリを触ってみましょう
  - これからはこのアプリにタスクを登録して開発を進めましょう
  - ※ ただし、Herokuのアプリケーションはインターネットでどこでも参照できるので、公開してはまずい情報は載せないようにしましょう
    - Basic認証をこの時点でいれてもいいかもしれません
- 今後、ステップが終わるたびにHerokuへ自分のアプリを継続的にデプロイしましょう
- デプロイの方法を README.md に記載しましょう
 - その際に、このアプリで使っているフレームワークのバージョン情報なども記載しておくとなおよいです

# このステップでやったこと
- basic認証をapplication_controllerに記載。`heroku config:add`でユーザを追加。
適用されるのはこのブランチがmasterにマージされたとき。
![image](https://user-images.githubusercontent.com/54347899/90587668-e5bfd880-e214-11ea-89b6-a41b6575c191.png)

- READMEにデプロイの方法とバージョン情報を記載。

# 動作確認
省略


# 参考資料
- [heroku 初級編 - GitHub から deploy してみよう -](https://qiita.com/sho7650/items/ebd87c5dc2c4c7abb8f0l)
- [Herokuで動かしているRailsアプリにベーシック認証を掛ける](https://takagi.blog/adding-basic-authentication-to-a-Rails-application-running-on-heroku/)