### PR TITLE
[step23]Admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'bullet'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,9 @@ GEM
     bootsnap (1.4.7)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bullet (6.1.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.33.0)
       addressable
@@ -228,6 +231,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    uniform_notifier (1.13.0)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -245,6 +249,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
+  bullet
   byebug
   capybara (>= 2.15)
   coffee-rails (~> 4.2)

--- a/app/assets/javascripts/admin.coffee
+++ b/app/assets/javascripts/admin.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Admin controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -154,3 +154,40 @@
     border-bottom: 2px solid #157436;
     transform: translate(0px, 3px);
 }
+
+
+
+/* /admin */
+.input-user{
+    display: block;
+    padding: 10px;
+    width: 77%;
+    height: 40px;
+    font-size: 19px;
+    border: none;
+    border-bottom: solid 1px #ccc;
+    margin: 10px;
+}
+.submit-user{
+    display: block;
+    color: #000;
+    background-color: rgb(138, 43, 138);
+    border: none;
+    border-bottom: 5px solid rgb(65, 9, 65);
+    padding: 10px;
+    width: 100px;
+    font-size: 14px;
+    border-radius: 5px;
+    display: inline-block;
+    margin: 10px;
+    color: whitesmoke;
+}
+.submit-user:hover{
+    display: block;
+    margin-top: 13px;
+    margin-bottom: 20px;
+    color: #000;
+    border-bottom: 2px solid rgb(65, 9, 65);
+    transform: translate(0px, 5px);
+    color: whitesmoke;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -158,6 +158,10 @@
 
 
 /* /admin */
+.error-message{
+    color: tomato;
+    text-decoration: underline;
+}
 .input-user{
     display: block;
     padding: 10px;
@@ -167,6 +171,9 @@
     border: none;
     border-bottom: solid 1px #ccc;
     margin: 10px;
+}
+.input-user-edit{
+    height: 40px;
 }
 .submit-user{
     display: block;
@@ -190,4 +197,7 @@
     border-bottom: 2px solid rgb(65, 9, 65);
     transform: translate(0px, 5px);
     color: whitesmoke;
+}
+tr{
+    text-align: center;
 }

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,4 @@
+class AdminController < ApplicationController
+  def new
+  end
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,4 +1,13 @@
 class AdminController < ApplicationController
-  def new
+  def top
+    redirect_to(login_path) if !session[:login]
+    user = User.find(session[:login])
+
+    if user.is_admin
+      @users = User.all
+    else
+      @message = "権限がありません"
+    end
   end
+  
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -17,19 +17,14 @@ class AdminController < ApplicationController
 
   def new
     session[:error] = ""
-    def check_nil(param, param_name)
-      if param.blank?
-        session[:error] = "[ユーザ追加時のエラー]#{param_name}を入力してください"
-      end
-    end
 
     password = params[:password]
     password_confirm = params[:password_confirm]
     session[:error] = "パスワードが確認用と一致しません" if password != password_confirm
 
-    check_nil(params[:password_confirm], "パスワード (確認用) ")
-    check_nil(params[:password], "パスワード")
-    check_nil(params[:name], "ユーザ名")
+    check_nil(params[:password_confirm], "パスワード (確認用) ", "作成")
+    check_nil(params[:password], "パスワード", "作成")
+    check_nil(params[:name], "ユーザ名", "作成")
 
 
     if session[:error].blank?
@@ -53,15 +48,10 @@ class AdminController < ApplicationController
   end
 
   def edit
-    session[:error] = ""    
-    def check_nil(param, param_name)
-      if param.blank?
-        session[:error] = "[ユーザ編集時のエラー]#{param_name}を入力してください"
-      end
-    end
+    session[:error] = ""
 
-    check_nil(params[:password], "パスワード")
-    check_nil(params[:name], "ユーザ名")
+    check_nil(params[:password], "パスワード", "編集")
+    check_nil(params[:name], "ユーザ名", "編集")
 
     user = User.find(params[:id])
 
@@ -83,4 +73,9 @@ class AdminController < ApplicationController
       @message = "このユーザにはタスクがありません"
     end
   end
+
+  private
+    def check_nil(param, param_name, action_name)
+      session[:error] = "[ユーザ#{action_name}時のエラー]#{param_name}を入力してください" if param.blank?
+    end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -64,7 +64,10 @@ class AdminController < ApplicationController
     check_nil(params[:name], "ユーザ名")
 
     user = User.find(params[:id])
-    if session[:error].blank? && user.authenticate(params[:password])
+
+    session[:error] = "パスワードが違います" if !user.authenticate(params[:password])
+
+    if session[:error].blank?
       user.name = params[:name]
       user.is_admin = params[:is_admin]
       user.password = params[:password]

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -9,5 +9,43 @@ class AdminController < ApplicationController
       @message = "権限がありません"
     end
   end
+
+  def new
+    session[:error] = ""
+    def check_nil(param, param_name)
+      if param.blank?
+        session[:error] = "#{param_name}を入力してください"
+      end
+    end
+
+    password = params[:password]
+    password_confirm = params[:password_confirm]
+    session[:error] = "パスワードが確認用と一致しません" if password != password_confirm
+
+    check_nil(params[:password_confirm], "パスワード (確認用) ")
+    check_nil(params[:password], "パスワード")
+    check_nil(params[:name], "ユーザ名")
+
+
+    if session[:error].blank?
+      User.create({
+        password: password,
+        name: params[:name],
+        is_admin: false,
+        sort_state: 0
+      })
+    end
+    redirect_to(admin_path)
+  end
+  
+
+
+  def delete
+    user = User.find(params[:id])
+    user.destroy
+
+    redirect_to(admin_path)
+  end
+  
   
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -5,6 +5,11 @@ class AdminController < ApplicationController
 
     if user.is_admin
       @users = User.all
+
+      @task_count = {};
+      @users.each do |user|
+        @task_count[user.id] = Task.where(user_id: user.id).count
+      end 
     else
       @message = "権限がありません"
     end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -14,7 +14,7 @@ class AdminController < ApplicationController
     session[:error] = ""
     def check_nil(param, param_name)
       if param.blank?
-        session[:error] = "#{param_name}を入力してください"
+        session[:error] = "[ユーザ追加時のエラー]#{param_name}を入力してください"
       end
     end
 
@@ -46,6 +46,28 @@ class AdminController < ApplicationController
 
     redirect_to(admin_path)
   end
+
+  def edit
+    session[:error] = ""    
+    def check_nil(param, param_name)
+      if param.blank?
+        session[:error] = "[ユーザ編集時のエラー]#{param_name}を入力してください"
+      end
+    end
+
+    check_nil(params[:password], "パスワード")
+    check_nil(params[:name], "ユーザ名")
+
+    user = User.find(params[:id])
+    if session[:error].blank? && user.authenticate(params[:password])
+      user.name = params[:name]
+      user.is_admin = params[:is_admin]
+      user.password = params[:password]
+      user.save!
+    end
+    redirect_to(admin_path)
+  end
+  
   
   
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -4,12 +4,11 @@ class AdminController < ApplicationController
     user = User.find(session[:login])
 
     if user.is_admin
-      @users = User.all
+      @users = User.eager_load(:tasks).all
 
-      @task_count = {};
-      user_ids = Task.all.pluck(:user_id)
+      @task_count = {}
       @users.each do |user|
-        @task_count[user.id] = user_ids.count(user.id)
+        @task_count[user.id] = user.tasks.to_a.count
       end
     else
       @message = "権限がありません"
@@ -77,6 +76,11 @@ class AdminController < ApplicationController
     redirect_to(admin_path)
   end
   
-  
-  
+  def user_tasks
+    @tasks = Task.where(user_id: params[:id])
+    @user_name = User.find(params[:id]).name
+    if @tasks.count.zero?
+      @message = "このユーザにはタスクがありません"
+    end
+  end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -7,9 +7,10 @@ class AdminController < ApplicationController
       @users = User.all
 
       @task_count = {};
+      user_ids = Task.all.pluck(:user_id)
       @users.each do |user|
-        @task_count[user.id] = Task.where(user_id: user.id).count
-      end 
+        @task_count[user.id] = user_ids.count(user.id)
+      end
     else
       @message = "権限がありません"
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,25 +1,26 @@
 class HomeController < ApplicationController
   def top
-    redirect_to(login_path) if !session[:login]
-
-    if Category.where(user_id: session[:login]).count.zero?
-      Category.create(title: "sample", user_id: session[:login])
+    if !session[:login]
+      redirect_to(login_path)
+    else
+      if Category.where(user_id: session[:login]).count.zero?
+        Category.create(title: "sample", user_id: session[:login])
+      end
+  
+      user = User.find(session[:login])
+      @sort_state = user.sort_state
+      @is_admin = user.is_admin
+  
+      order = case @sort_state
+                when 0 then
+                  {deadline: :desc}
+                when 1 then
+                  {created_at: :desc}
+                when 2 then
+                  {updated_at: :desc}
+              end
+      @tasks = Task.where(user_id: session[:login]).order(order)
     end
-
-    user = User.find(session[:login])
-    @sort_state = user.sort_state
-    @is_admin = user.is_admin
-
-    order = case @sort_state
-              when 0 then
-                {deadline: :desc}
-              when 1 then
-                {created_at: :desc}
-              when 2 then
-                {updated_at: :desc}
-            end
-
-    @tasks = Task.where(user_id: session[:login]).order(order)
   end
 
   def sort_tasks

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,9 @@ class HomeController < ApplicationController
       Category.create(title: "sample", user_id: session[:login])
     end
 
-    @sort_state = User.find(session[:login]).sort_state
+    user = User.find(session[:login])
+    @sort_state = user.sort_state
+    @is_admin = user.is_admin
 
     order = case @sort_state
               when 0 then

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -33,7 +33,7 @@ class HomeController < ApplicationController
     redirect_to(root_path) if session[:login].present?
   end
 
-  def auth    
+  def auth
     id = params[:id]
     user = User.find_by(id: id)
 

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,0 +1,2 @@
+module AdminHelper
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,6 @@
 class Category < ApplicationRecord
   belongs_to :user
-  has_many :categories
+  has_many :tasks, dependent: :destroy
 
   validates :title, presence: true, length: {maximum: 30}
   validates :user_id, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
-    has_many :categories
-    has_many :tasks
+    has_many :tasks, dependent: :destroy
+    has_many :categories, dependent: :destroy
     has_secure_password
 
     validates :name, presence: true, length: {maximum: 30}

--- a/app/views/admin/new.html.slim
+++ b/app/views/admin/new.html.slim
@@ -1,0 +1,2 @@
+h1 Admin#new
+p Find me in app/views/admin/new.html.slim

--- a/app/views/admin/top.html.slim
+++ b/app/views/admin/top.html.slim
@@ -1,4 +1,4 @@
-head
+header
     h1 管理者画面
     h2 = "あなたのIDは#{session[:login]}です"
     -if session[:error].present?
@@ -6,11 +6,15 @@ head
 
 
 main
+    h2
+        = link_to("タスク一覧", "../")
+    = form_with url: logout_path, local: true do |f|
+        = f.submit "ログアウト", class:"delete-btn delete-task"
     = form_with url: admin_new_path, local: true do |f|
         = f.text_field :name, class: "input-user", placeholder: "ユーザ名"
         = f.password_field :password, class: "input-user", placeholder: "パスワード"
         = f.password_field :password_confirm, class: "input-user", placeholder: "パスワード (確認用)"
-        = f.submit '完了', class: "submit-user"
+        = f.submit 'ユーザ追加', class: "submit-user"
 
     br/
     br/

--- a/app/views/admin/top.html.slim
+++ b/app/views/admin/top.html.slim
@@ -1,7 +1,37 @@
-div
+head
+    h1 管理者画面
+    h2 = "あなたのIDは#{session[:login]}です"
+    -if session[:error].present?
+        h4 = session[:error]
+
+
+main
+    = form_with url: admin_new_path, local: true do |f|
+        = f.text_field :name, class: "input-user", placeholder: "ユーザ名"
+        = f.text_field :password, class: "input-user", placeholder: "パスワード"
+        = f.text_field :password_confirm, class: "input-user", placeholder: "パスワード (確認用)"
+        = f.submit '完了', class: "submit-user"
+
+    br/
+    br/
+
     -if @message.blank?
-        -@users.each do |user|
-            li = user.name
+        table
+            th ユーザID
+            th ユーザ名
+            th 管理者権限
+            th 
+            -@users.each do |user|
+                tr
+                    td = user.id
+                    td = user.name
+                    -if user.is_admin
+                        td あり
+                    -else
+                        td なし
+                    td = form_with url: admin_delete_path, local: true do |f|
+                        = f.text_field :id , class: "hidden", value: user.id
+                        = f.submit '削除', class: "delete-btn delete-task", "@click": "deleteTask"
+
     -else
         h1 =@message
-        

--- a/app/views/admin/top.html.slim
+++ b/app/views/admin/top.html.slim
@@ -2,14 +2,14 @@ head
     h1 管理者画面
     h2 = "あなたのIDは#{session[:login]}です"
     -if session[:error].present?
-        h4 = session[:error]
+        h4.error-message = session[:error]
 
 
 main
     = form_with url: admin_new_path, local: true do |f|
         = f.text_field :name, class: "input-user", placeholder: "ユーザ名"
-        = f.text_field :password, class: "input-user", placeholder: "パスワード"
-        = f.text_field :password_confirm, class: "input-user", placeholder: "パスワード (確認用)"
+        = f.password_field :password, class: "input-user", placeholder: "パスワード"
+        = f.password_field :password_confirm, class: "input-user", placeholder: "パスワード (確認用)"
         = f.submit '完了', class: "submit-user"
 
     br/
@@ -19,16 +19,20 @@ main
         table
             th ユーザID
             th ユーザ名
+            th パスワード(必須)
             th 管理者権限
-            th 
             -@users.each do |user|
                 tr
-                    td = user.id
-                    td = user.name
-                    -if user.is_admin
-                        td あり
-                    -else
-                        td なし
+                    = form_with url: admin_edit_path, local: true do |f|
+                        td 
+                            = user.id 
+                            = f.hidden_field :id, value: user.id
+                        td = f.text_field :name, class: "input-user-edit", value: user.name
+                        td = f.password_field :password, class: "input-user-edit", value: user.password
+                        td = f.check_box  :is_admin, {checked: user.is_admin}, "true", "false"
+
+                        td = f.submit '更新', class: "submit-btn"
+
                     td = form_with url: admin_delete_path, local: true do |f|
                         = f.text_field :id , class: "hidden", value: user.id
                         = f.submit '削除', class: "delete-btn delete-task", "@click": "deleteTask"

--- a/app/views/admin/top.html.slim
+++ b/app/views/admin/top.html.slim
@@ -1,0 +1,7 @@
+div
+    -if @message.blank?
+        -@users.each do |user|
+            li = user.name
+    -else
+        h1 =@message
+        

--- a/app/views/admin/top.html.slim
+++ b/app/views/admin/top.html.slim
@@ -21,6 +21,7 @@ main
             th ユーザ名
             th パスワード(必須)
             th 管理者権限
+            th 保持タスク数
             -@users.each do |user|
                 tr
                     = form_with url: admin_edit_path, local: true do |f|
@@ -30,6 +31,7 @@ main
                         td = f.text_field :name, class: "input-user-edit", value: user.name
                         td = f.password_field :password, class: "input-user-edit", value: user.password
                         td = f.check_box  :is_admin, {checked: user.is_admin}, "true", "false"
+                        td = @task_count[user.id]
 
                         td = f.submit '更新', class: "submit-btn"
 

--- a/app/views/admin/top.html.slim
+++ b/app/views/admin/top.html.slim
@@ -6,8 +6,7 @@ header
 
 
 main
-    h2
-        = link_to("タスク一覧", "../")
+    h2 = link_to("タスク一覧画面へ", "#{request.protocol}#{request.host}")
     = form_with url: logout_path, local: true do |f|
         = f.submit "ログアウト", class:"delete-btn delete-task"
     = form_with url: admin_new_path, local: true do |f|
@@ -41,7 +40,8 @@ main
 
                     td = form_with url: admin_delete_path, local: true do |f|
                         = f.text_field :id , class: "hidden", value: user.id
-                        = f.submit '削除', class: "delete-btn delete-task", "@click": "deleteTask"
+                        = f.submit '削除', class: "delete-btn delete-task"
+                    td = link_to("このユーザのタスクを見る", "#{request.protocol}#{request.host}/admin/user/#{user.id}/tasks")
 
     -else
         h1 =@message

--- a/app/views/admin/user_tasks.html.slim
+++ b/app/views/admin/user_tasks.html.slim
@@ -1,0 +1,34 @@
+div
+    h1 = "#{@user_name}さんのタスク一覧"
+    h2 = link_to("管理画面にもどる", "#{request.protocol}#{request.host}/admin") 
+    -@tasks.each do |task|
+        h2 = task.title
+        div
+            li = "ID: #{task.id}"
+            li = "締め切り:#{task.deadline}"
+            -case task.priority
+            -when 0
+                li = "優先度: 低"
+            -when 1
+                li = "優先度: 中"
+            -when 2
+                li = "優先度: 高"
+            -else
+                li = "優先度: 未設定"
+            
+            -case task.state
+            -when 0
+                li = "ステータス: 未着手"
+            -when 1
+                li = "ステータス: 着手"
+            -when 2
+                li = "ステータス: 完了"
+            -else
+                li = "ステータス: 未設定"
+
+            div
+                = task.memo
+            
+    
+    -if @message.present?
+        h2 = @message

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -12,8 +12,7 @@ body
             h2 = l(Time.current)
             h2 = "あなたのIDは #{session[:login]}です"
             -if @is_admin
-                h2
-                    = link_to("管理者ページ", "/admin")
+                h2 = link_to("管理者画面へ", "#{request.protocol}#{request.host}/admin")
 
         main
             = form_with url: logout_path, local: true do |f|

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -11,6 +11,9 @@ body
             h2 = t 'greetings.hello'
             h2 = l(Time.current)
             h2 = "あなたのIDは #{session[:login]}です"
+            -if @is_admin
+                h2
+                    = link_to("管理者ページ", "/admin")
 
         main
             = form_with url: logout_path, local: true do |f|

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,10 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+Bullet.enable = true
+Bullet.alert = true
+Bullet.bullet_logger = true
+Bullet.console = true
+Bullet.rails_logger = true
+Bullet.add_footer = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'admin/new'
   root to: 'home#top'
   post '/' => 'home#sort_tasks'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   get 'admin/' => 'admin#top'
   post 'admin/new' => 'admin#new'
   post 'admin/delete' => 'admin#delete'
+  post 'admin/edit' => 'admin#edit'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   post 'admin/new' => 'admin#new'
   post 'admin/delete' => 'admin#delete'
   post 'admin/edit' => 'admin#edit'
+  get 'admin/user/:id/tasks' => 'admin#user_tasks'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get 'admin/new'
   root to: 'home#top'
   post '/' => 'home#sort_tasks'
 
@@ -12,6 +11,9 @@ Rails.application.routes.draw do
   post 'js/ajax_edit', to: 'js#ajax_edit'
   post 'js/ajax_delete', to: 'js#ajax_delete'
   post 'js/ajax_before_edit', to: 'js#ajax_before_edit'
+
+  get 'admin/' => 'admin#top'
+  post 'admin/new' => 'admin#new'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
 
   get 'admin/' => 'admin#top'
   post 'admin/new' => 'admin#new'
+  post 'admin/delete' => 'admin#delete'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe AdminController, type: :controller do
+
+  describe "GET #new" do
+    it "returns http success" do
+      get :new
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the AdminHelper. For example:
+#
+# describe AdminHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe AdminHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/admin/new.html.slim_spec.rb
+++ b/spec/views/admin/new.html.slim_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "admin/new.html.slim", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# このステップの内容
- 画面上に管理メニューを追加しましょう
- 管理画面にはかならず `/admin` というURLを先頭につけるようにしましょう
  - `routes.rb` に追加する前に、あらかじめURLやルーティング名（ `*_path` となる名前）を想定して設計してみましょう
- ユーザ一覧・作成・更新・削除を実装しましょう
- ユーザを削除したら、そのユーザが抱えているタスクを削除するようにしてみましょう
- ユーザの一覧画面で、ユーザが持っているタスクの数を表示するようにしてみましょう
  - N+1問題を回避するための仕組みを取り入れましょう
- ユーザが作成したタスクの一覧が見られるようにしてみましょう

# このステップでやったこと
### `/admin`配下のページ作成
`/admin`配下に管理機能をつけたページを作成し、ユーザの作成・編集・削除する機能を実装をした。増えたページはユーザ一覧を表示する管理者画面と、各ユーザごとに保持するタスク一覧を表示するページの2ページ。ログイン画面やタスク一覧画面との行き来もできるようにした。

### レコードが削除されたとき、それに関連するレコードも削除する
モデルで`has_many`が指定されているところに`dependent: :destroy`を追加し、関連レコードの削除を自動で行ってくれるようにした。

# 動作確認
### ブラウザ
##### 検証観点
- [x] ユーザの追加が正しく行えること
- [x] ユーザ情報の更新が正しく行えること
- [x] ユーザの削除が正しく行えること
- [x] ユーザの削除後に、ユーザの保持するタスクも削除されること
- [x] 管理画面でユーザごとにタスクの一覧が表示されること

##### 検証結果
ユーザ追加・編集・削除が期待通り動作することを確認
![1](https://user-images.githubusercontent.com/54347899/91440178-24a2fd80-e8a9-11ea-9e6c-ff1aed08b712.gif)

ユーザIDが45のユーザを削除後、そのユーザが持つタスクが0であることを確認
![image](https://user-images.githubusercontent.com/54347899/91442371-b6603a00-e8ac-11ea-85c3-d783ce0bbd43.png)

各ユーザの保持するタスクを表示することを確認
![image](https://user-images.githubusercontent.com/54347899/91444075-2e2f6400-e8af-11ea-8f3f-94b69a3e14d3.png)



### Spec



# 参考資料
参考にした記事などがあれば載せる