### PR TITLE
[step25]タスクのカテゴライズ

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -20,7 +20,12 @@
  .validation-message{
      list-style: none;
  }
-.task-title{
+ .category-title-link{
+    text-decoration: none;
+    color: #333;
+    font-weight: bolder;
+ }
+.task-title, .category-title{
     list-style: none;
     font-size: 19px;
     background-color: #aaaa;
@@ -28,7 +33,7 @@
     margin: 5px 0 0 5px;
     border-radius: 10px;
 }
-.task-title:hover{
+.task-title:hover, .category-title:hover{
     opacity: 0.5;
 }
 .hidden{

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -41,7 +41,7 @@ class AdminController < ApplicationController
 
 
   def delete
-    user = User.find(params[:id]).eager_load(:tasks)
+    user = User.eager_load(:tasks).find(params[:id])
     user.destroy
 
     redirect_to(admin_path)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,6 +1,6 @@
 class AdminController < ApplicationController
   def top
-    redirect_to(login_path) if !session[:login]
+    return redirect_to(login_path) unless session[:login].present?
     user = User.find(session[:login])
 
     if user.is_admin
@@ -41,7 +41,7 @@ class AdminController < ApplicationController
 
 
   def delete
-    user = User.find(params[:id])
+    user = User.find(params[:id]).eager_load(:tasks)
     user.destroy
 
     redirect_to(admin_path)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -61,4 +61,12 @@ class HomeController < ApplicationController
     redirect_to(login_path)
   end
   
+  def show_search_results
+    @categories = Category.where('title LIKE ?', "%#{params[:query]}%")
+  end
+
+  def search
+    redirect_to("#{request.protocol}#{request.host}/search/#{params[:query]}")
+  end
+
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,5 @@
 class HomeController < ApplicationController
   def top
-    
     return redirect_to(login_path) unless session[:login].present?
 
     if Category.where(user_id: session[:login]).count.zero?
@@ -19,7 +18,12 @@ class HomeController < ApplicationController
               when 2 then
                 {updated_at: :desc}
             end
-    @tasks = Task.where(user_id: session[:login]).order(order)
+    @categories = Category.where(user_id: session[:login])
+  end
+
+  def show_tasks
+    @category = Category.find(params[:id])
+    @tasks = Task.where(category_id: params[:id])
   end
 
   def sort_tasks

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,26 +1,25 @@
 class HomeController < ApplicationController
   def top
-    if !session[:login]
-      redirect_to(login_path)
-    else
-      if Category.where(user_id: session[:login]).count.zero?
-        Category.create(title: "sample", user_id: session[:login])
-      end
-  
-      user = User.find(session[:login])
-      @sort_state = user.sort_state
-      @is_admin = user.is_admin
-  
-      order = case @sort_state
-                when 0 then
-                  {deadline: :desc}
-                when 1 then
-                  {created_at: :desc}
-                when 2 then
-                  {updated_at: :desc}
-              end
-      @tasks = Task.where(user_id: session[:login]).order(order)
+    
+    return redirect_to(login_path) unless session[:login].present?
+
+    if Category.where(user_id: session[:login]).count.zero?
+      Category.create(title: "sample", user_id: session[:login])
     end
+
+    user = User.find(session[:login])
+    @sort_state = user.sort_state
+    @is_admin = user.is_admin
+
+    order = case @sort_state
+              when 0 then
+                {deadline: :desc}
+              when 1 then
+                {created_at: :desc}
+              when 2 then
+                {updated_at: :desc}
+            end
+    @tasks = Task.where(user_id: session[:login]).order(order)
   end
 
   def sort_tasks

--- a/app/controllers/js_controller.rb
+++ b/app/controllers/js_controller.rb
@@ -1,23 +1,32 @@
 class JsController < ApplicationController
   def ajax_create
-    @title = params[:newTaskTitle]
     @message = ''
-
-    @newTask = Task.create(
-      title: @title,
-      deadline: Time.zone.now + 1.day,
-      priority: rand(0..2),
-      state: rand(0..2),
-      memo: 'test',
-      user_id: session[:login],
-      category_id: Category.where(user_id: session[:login]).first.id
-    )
-    if @newTask.valid?
-      @id = @newTask.id
-    else
-      @message = @newTask.errors.full_messages
+    if params[:newTaskTitle]
+      @newTask = Task.create(
+        title: params[:newTaskTitle],
+        deadline: Time.zone.now + 1.day,
+        priority: rand(0..2),
+        state: rand(0..2),
+        memo: 'test',
+        user_id: session[:login],
+        category_id: params[:category_id]
+      )
+      if @newTask.valid?
+        @id = @newTask.id
+        redirect_to("#{request.protocol}#{request.host}/category/#{params[:category_id]}")
+      else
+        @message = @newTask.errors.full_messages
+      end
+    elsif params[:newCategoryTitle]
+      @newCategory = Category.create(
+        title: params[:newCategoryTitle],
+        user_id: session[:login]
+      )
+      unless @newCategory.valid?
+        @message = @newTask.errors.full_messages
+      end
+      redirect_to(root_path)
     end
-    render
   end
 
   def ajax_before_edit
@@ -28,27 +37,42 @@ class JsController < ApplicationController
   def ajax_edit
     @message = ''
 
-    @task = Task.find(params[:task_id])
-    @task.title = params[:title]
-    @task.deadline = params[:deadline]
-    @task.priority = params[:priority]
-    @task.state = params[:state]
-    @task.memo = params[:memo]
-    @task.save
-
-    if !@task.valid?
-      @message = @task.errors.full_messages
+    if params[:task_id].present?
+      @task = Task.find(params[:task_id])
+      @task.title = params[:title]
+      @task.deadline = params[:deadline]
+      @task.priority = params[:priority]
+      @task.state = params[:state]
+      @task.memo = params[:memo]
+      @task.save
+      unless @task.valid?
+        @message = @task.errors.full_messages
+      end
+    elsif params[:category_id].present?
+      @category = Category.find(params[:category_id])
+      @category.title = params[:category_title]
+      @category.save
+      unless @category.valid?
+        @message = category.errors.full_messages
+      end
     end
+    
+
     
     render
   end
 
   def ajax_delete
-    @task_id = params[:task_id]
-    @task = Task.find(@task_id)
-    @task.destroy
-
-    render
+    if params[:task_id].present?
+      @id = params[:task_id]
+      task = Task.find(@id)
+      task.destroy
+    elsif params[:category_id].present?
+      @id = params[:category_id]
+      category = Category.eager_load(:tasks).find(@id)
+      category.destroy
+      redirect_to(root_path)
+    end
   end
 
 end

--- a/app/views/home/show_search_results.html.slim
+++ b/app/views/home/show_search_results.html.slim
@@ -1,0 +1,18 @@
+
+h2 = link_to("←カテゴリ一覧へ", "#{request.protocol}#{request.host}/")
+h1 = "検索結果: #{params[:query]}"
+= form_with url: search_path, local: true do |f|
+    = f.text_field :query, class: "input-task-title", placeholder: "カテゴリの検索"
+    = f.submit '完了', class: "submit-btn submit-task-title", "@click": "submitNewTask"
+
+div.validation-message.hidden#validation-message-create
+    li v-for="message in validationMessages.create" v-html="message"
+
+div#categories-container
+    -@categories.each do |category|
+        div.category-container
+            a class="category-title-link" href="#{request.protocol}#{request.host}/category/#{category.id}" 
+                | <li class='category-title'>#{category.title}</li>
+            = form_with url: js_ajax_delete_path, local: true do |f|
+                = f.text_field :category_id, class: "hidden", value: category.id
+                = f.submit '削除', class: "delete-btn delete-task", "@click": "deleteTask"

--- a/app/views/home/show_tasks.html.slim
+++ b/app/views/home/show_tasks.html.slim
@@ -1,59 +1,51 @@
 head
-    meta charset="UTF-8"/
-    meta name="viewport" content="width=device-width, initial-scale=1.0"/
-    title Document
     script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"
-    / script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"
-    / 本番環境 script src="https://cdn.jsdelivr.net/npm/vue@2.6.11"
-body
-    div#vm-container
-        header
-            h2 = t 'greetings.hello'
-            h2 = l(Time.current)
-            h2 = "あなたのIDは #{session[:login]}です"
-            -if @is_admin
-                h2 = link_to("管理者画面へ", "#{request.protocol}#{request.host}/admin")
 
-        main
-            = form_with url: logout_path, local: true do |f|
-                = f.submit "ログアウト", class:"delete-btn delete-task"
-            
-            h1 カテゴリ一覧
+div#vm-container
+    h2 = link_to("←カテゴリ一覧へ", "#{request.protocol}#{request.host}/")
+    h1#category-title v-if="isShow.categoryTitle" @click="toggleTextboxForCategoryTitle" {{categoryTitle}}
 
-            = form_with url: js_ajax_create_path, local: true do |f|
-                = f.text_field :newCategoryTitle, class: "input-task-title", "v-model": "newCategoryTitle", placeholder: "カテゴリの追加"
-                = f.submit '完了', class: "submit-btn submit-task-title", "@click": "submitNewTask"
+    = form_with url: js_ajax_edit_path do |f|
+        = f.text_field :category_title, class: "input-task-title", "v-if": "!isShow.categoryTitle", "v-model": "categoryTitle", placeholder: "タスクタイトル", value: "#{@category.title}"
+        = f.hidden_field :category_id, class: "hidden", value: params[:id]
+        = f.submit '完了', class: "submit-btn submit-category-title", "v-if": "!isShow.categoryTitle"
 
-            div.validation-message.hidden#validation-message-create
-                li v-for="message in validationMessages.create" v-html="message"
+    = form_with url: js_ajax_create_path, local: true do |f|
+        = f.text_field :newTaskTitle, class: "input-task-title", "v-model": "newTaskTitle", placeholder: "タスクの追加"
+        = f.hidden_field :category_id, class: "hidden", value: params[:id]
+        = f.submit '完了', class: "submit-btn submit-task-title", "@click": "submitNewTask"
 
-            div#categories-container
-                -@categories.each do |category|
-                    div.category-container
-                        a class="category-title-link" href="#{request.protocol}#{request.host}/category/#{category.id}" 
-                            | <li class='category-title'>#{category.title}</li>
-                        = form_with url: js_ajax_delete_path, local: true do |f|
-                            = f.text_field :category_id, class: "hidden", value: category.id
-                            = f.submit '削除', class: "delete-btn delete-task", "@click": "deleteTask"
+    div#tasks-container
+        -@tasks.each do |task|
+            div.task-container
+                li.task-title = task.title 
+                span.hidden.task-id = task.id
+                span.hidden.deadline = task.deadline
+                span.hidden.priority = task.priority
+                span.hidden.state = task.state
+                span.hidden.memo = task.memo
+                = form_with url: js_ajax_delete_path do |f|
+                    = f.text_field :task_id, class: "hidden", value: task.id
+                    = f.submit '削除', class: "delete-btn delete-task", "@click": "deleteTask"
+    
+    div.modal-close#modal-background @click="hideModal"
 
-            div.modal-close#modal-background @click="hideModal"
-
-            div.modal#modal-edit
-                div.modal-content#modal-edit-content
-                    = form_with url: js_ajax_edit_path do |f|
-                        = f.text_field :task_id, class: "hidden", "v-model": "edittingTask.task_id"
-                        = f.text_field :title, class: "input-edit", placeholder: "タスク名", "v-model": "edittingTask.title"
-                        = f.datetime_field :deadline, class: "input-edit", "v-model": "edittingTask.deadline"
-                        = f.select :priority, [["低", "0"], ["中", "1"], ["高", "2"]], "v-model": "edittingTask.priority"
-                        = f.select :state, [["未着手", "0"], ["着手", "1"], ["完了", "2"]], "v-model": "edittingTask.state"
-                        = f.text_area :memo, class: "input-edit", "v-model": "edittingTask.memo"
-                        = f.submit '完了', class: "submit-btn submit-editted-title", "@click": "submitEditedTask"
-                    div.validation-message.hidden#validation-message-edit
-                        li v-for="message in validationMessages.edit" v-html="message"
+    div.modal#modal-edit
+        div.modal-content#modal-edit-content
+            = form_with url: js_ajax_edit_path do |f|
+                = f.text_field :task_id, class: "hidden", "v-model": "edittingTask.task_id"
+                = f.text_field :title, class: "input-edit", placeholder: "タスク名", "v-model": "edittingTask.title"
+                = f.datetime_field :deadline, class: "input-edit", "v-model": "edittingTask.deadline"
+                = f.select :priority, [["低", "0"], ["中", "1"], ["高", "2"]], "v-model": "edittingTask.priority"
+                = f.select :state, [["未着手", "0"], ["着手", "1"], ["完了", "2"]], "v-model": "edittingTask.state"
+                = f.text_area :memo, class: "input-edit", "v-model": "edittingTask.memo"
+                = f.submit '完了', class: "submit-btn submit-editted-title", "@click": "submitEditedTask"
+            div.validation-message.hidden#validation-message-edit
+                li v-for="message in validationMessages.edit" v-html="message"
                 
-        footer
-            div#flash-message.hidden 
-                | {{ flashMessage }}
+    footer
+        div#flash-message.hidden 
+            | {{ flashMessage }}
 
 
 javascript:
@@ -65,7 +57,7 @@ javascript:
                 create: [],
                 edit: []
             },
-            newCategoryTitle: '',
+            newTaskTitle: '',
             edittingTask: {
                 task_id: '',
                 title: '',
@@ -73,7 +65,11 @@ javascript:
                 priority: '',
                 state: '',
                 memo: ''
-            }
+            },
+            isShow: {
+                categoryTitle: true
+            },
+            categoryTitle: "#{@category.title}"
         },
         methods: {
             showModal: function(){
@@ -160,8 +156,10 @@ javascript:
                 setTimeout(function(){
                     $(element).addClass('hidden');
                 }, 2000);
+            },
+            toggleTextboxForCategoryTitle: function(){
+                this.isShow.categoryTitle = !this.isShow.categoryTitle;
             }
-
         },
         created: function(){
             // Vueの嬉しさを全く活かさない書き方😞

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -20,6 +20,11 @@ body
             
             h1 カテゴリ一覧
 
+
+            = form_with url: search_path, local: true do |f|
+                = f.text_field :query, class: "input-task-title", placeholder: "カテゴリの検索"
+                = f.submit '完了', class: "submit-btn submit-task-title", "@click": "submitNewTask"
+
             = form_with url: js_ajax_create_path, local: true do |f|
                 = f.text_field :newCategoryTitle, class: "input-task-title", "v-model": "newCategoryTitle", placeholder: "カテゴリの追加"
                 = f.submit '完了', class: "submit-btn submit-task-title", "@click": "submitNewTask"

--- a/app/views/js/ajax_create.js.erb
+++ b/app/views/js/ajax_create.js.erb
@@ -2,17 +2,4 @@ if('<%= "#{ @message }" %>'){
     const message = '<%= "#{ @message }" %>';
     messageArray = message.split(',');
     vm.displayValidationMessage(messageArray, 'create', '#validation-message-create');
-}else{
-    createTask('<%= "#{ @title }" %>', '<%= "#{ @id }" %>');
-
-    function createTask(title, id){
-        $('#tasks-container').prepend(`
-            <div class="task-container">
-                <li class="task-title" @click="editTask">` + title + `</li>
-                <span class="task-id">` + id + `</span>
-            </div>
-        `);
-        vm.newTaskTitle = '';
-        vm.displayFlashMessage('タスクを作成した！', 'success');
-    }
 }

--- a/app/views/js/ajax_delete.js.erb
+++ b/app/views/js/ajax_delete.js.erb
@@ -1,6 +1,6 @@
-deleteTask('<%= "#{ @task_id }" %>');
+deleteTask('<%= "#{ @id }" %>');
 
-function deleteTask(task_id){
+function deleteTask(id){
     // Vueの嬉しさを全く活かさない書き方😞
     const taskElements = document.getElementsByClassName('task-container');
     console.log(taskElements.length);
@@ -8,7 +8,7 @@ function deleteTask(task_id){
     for(let i = 0; i < taskElements.length; i++){
         checkingId = taskElements[i].querySelector('span').textContent;
         
-        if(checkingId == task_id){
+        if(checkingId == id){
             taskElements[i].parentNode.removeChild(taskElements[i]);
             vm.displayFlashMessage('タスクを削除した！', 'success');
 

--- a/app/views/js/ajax_edit.js.erb
+++ b/app/views/js/ajax_edit.js.erb
@@ -3,14 +3,18 @@ if('<%= "#{ @message }" %>'){
     messageArray = message.split(',');
     vm.displayValidationMessage(messageArray, 'edit', '#validation-message-edit');
 }else{
-    editTask(
-        '<%= "#{ @task.id }" %>',
-        '<%= "#{ @task.title }" %>',
-        '<%= "#{ @task.deadline }" %>',
-        '<%= "#{ @task.priority }" %>',
-        '<%= "#{ @task.state }" %>',
-        '<%= "#{ @task.memo }" %>'
-    );
+    <% if @task.present? %>
+        editTask(
+            '<%= "#{ @task.id }" %>',
+            '<%= "#{ @task.title }" %>',
+            '<%= "#{ @task.deadline }" %>',
+            '<%= "#{ @task.priority }" %>',
+            '<%= "#{ @task.state }" %>',
+            '<%= "#{ @task.memo }" %>'
+        );
+    <% elsif @category.present? %>
+        editCategory();
+    <% end %>
 }
 
 function editTask(task_id, title, deadline, priority, state, memo){
@@ -40,4 +44,8 @@ function editTask(task_id, title, deadline, priority, state, memo){
             return false;
         }
     }
+}
+
+function editCategory(){
+    vm.isShow.categoryTitle = !vm.isShow.categoryTitle;
 }

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,10 +3,3 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
-
-Bullet.enable = true
-Bullet.alert = true
-Bullet.bullet_logger = true
-Bullet.console = true
-Bullet.rails_logger = true
-Bullet.add_footer = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,4 +58,11 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  Bullet.enable = true
+  Bullet.alert = true
+  Bullet.bullet_logger = true
+  Bullet.console = true
+  Bullet.rails_logger = true
+  Bullet.add_footer = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   root to: 'home#top'
   post '/' => 'home#sort_tasks'
   get 'category/:id' => 'home#show_tasks'
+  get 'search/:query' => 'home#show_search_results'
+  post 'search' => 'home#search'
 
   get 'login' => 'home#login'
   post 'login' => 'home#auth'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   root to: 'home#top'
   post '/' => 'home#sort_tasks'
+  get 'category/:id' => 'home#show_tasks'
 
   get 'login' => 'home#login'
   post 'login' => 'home#auth'


### PR DESCRIPTION
# このステップの内容
### ステップ25: タスクにラベルをつけられるようにしよう

- タスクに複数のラベルをつけられるようにしてみましょう
- つけたラベルで検索できるようにしてみましょう

# このステップでやったこと
「ラベル」を「カテゴリ」として、以下のように実装:
ルートではカテゴリの一覧 (Category:Task = 1:N) を表示する。カテゴリを選択すると、そのカテゴリに属するタスクを一覧表示するページ (`category/:id`) に移動。タスク一覧ページからは従来通りタスクの作成・削除・更新が行える。ルートのカテゴリ一覧からは、カテゴリの作成・削除・更新を行う。

### カテゴリ一覧ページの作成
これまでタスクの一覧表示をしていたトップページでは、カテゴリの一覧を表示するようにした。このページからはカテゴリの追加・削除・検索を行えるようにした。カテゴリの削除を行った時はそのカテゴリに属するタスクも一緒に削除されるようにした。

### タスク一覧ページの作成
`category/:id`で`Task.where(category_id: params[:id])`となるタスクを一覧表示。このページからタスクの作成・削除・更新と、カテゴリ名の更新が行えるようにした。

### カテゴリ検索結果を表示するページの作成
カテゴリ一覧のページからカテゴリ名の検索を行い、検索結果の表示を`search/:query`で表示するようにした。

# 動作確認
### ブラウザ
##### 検証観点
- [x] カテゴリ一覧画面で、カテゴリの作成と削除ができること
- [x] タスク一覧画面で、タスクの作成・削除・更新ができること
- [x] カテゴリ一覧画面で、タスクの検索ができること

##### 検証結果

カテゴリの作成と削除が成功したことを確認
![1](https://user-images.githubusercontent.com/54347899/91628008-9ccb0980-e9f6-11ea-9a3a-00972715bb0d.gif)

カテゴリの作成・削除・更新が成功したことを確認
![2](https://user-images.githubusercontent.com/54347899/91628558-de11e800-e9fb-11ea-9126-cc81c6703f58.gif)

カテゴリ名で検索が成功したことを確認
![3](https://user-images.githubusercontent.com/54347899/91628841-a0fb2500-e9fe-11ea-9d1a-d6ec9bb6f5a2.gif)


### Spec



# 参考資料
[Rails 検索機能でよく使われる表現 あいまい検索](https://qiita.com/kinokosan/items/7a07bd2a307571c68335)